### PR TITLE
#32: removed --stacktrace from CI build step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,4 +29,4 @@ jobs:
 
     # Runs a single command using the runners shell
     - name: Compile and run tests on robot code
-      run: ./gradlew build --stacktrace
+      run: ./gradlew build


### PR DESCRIPTION
**Changes**
- Build step no longer has `--stacktrace`

**Verification**
- Look at the ci.yaml file

Closes #32 